### PR TITLE
Added Distance Units for the scale widget, parametrised QT version.

### DIFF
--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -5,21 +5,16 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-find_package(Qt6 COMPONENTS
-             Core
-             Gui
-             Network
-             Widgets
-            )
-if (NOT Qt6_FOUND)
-   message("Qt6 components not found.  Attempting to find Qt5 components...")
-   find_package(Qt5 REQUIRED COMPONENTS
-                Core
-                Gui
-                Widgets
-                Network
-               )
-endif()
+# Set the QT version
+set(QT_VERSION 5)
+
+find_package(Qt${QT_VERSION} REQUIRED COMPONENTS
+        Core
+        Gui
+        Widgets
+        Network
+        )
+
 
 add_executable(qgeoview-demo
     main.cpp
@@ -58,22 +53,13 @@ add_executable(qgeoview-demo
     samples/mytile.h
 )
 
-if (Qt6_FOUND)
-    target_link_libraries(qgeoview-demo
-                          PRIVATE
-                          Qt6::Core
-                          Qt6::Network
-                          Qt6::Gui
-                          Qt6::Widgets
-                          QGeoView
-                         )
-else()
-    target_link_libraries(qgeoview-demo
-                          PRIVATE
-                          Qt5::Core
-                          Qt5::Network
-                          Qt5::Gui
-                          Qt5::Widgets
-                          QGeoView
-                         )
-endif()
+
+target_link_libraries(qgeoview-demo
+        PRIVATE
+        Qt${QT_VERSION}::Core
+        Qt${QT_VERSION}::Network
+        Qt${QT_VERSION}::Gui
+        Qt${QT_VERSION}::Widgets
+        QGeoView
+        )
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -53,7 +53,7 @@ add_library(qgeoview SHARED
     src/QGVWidgetScale.cpp
     src/QGVWidgetZoom.cpp
     src/QGVWidgetText.cpp
-)
+        src/utils/DistanceUnits.cpp include/QGeoView/utils/DistanceUnits.hpp)
 
 target_include_directories(qgeoview
     PUBLIC

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,21 +1,15 @@
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt6 COMPONENTS
+# Set the QT version
+set(QT_VERSION 5)
+
+find_package(Qt${QT_VERSION} REQUIRED COMPONENTS
              Core
              Gui
              Widgets
              Network
             )
-if (NOT Qt6_FOUND)
-   message("Qt6 components not found.  Attempting to find Qt5 components...")
-   find_package(Qt5 REQUIRED COMPONENTS
-                Core
-                Gui
-                Widgets
-                Network
-               )
-endif()
 
 add_library(qgeoview SHARED
     include/QGeoView/QGVGlobal.h
@@ -76,24 +70,14 @@ target_compile_definitions(qgeoview
         QGV_EXPORT
 )
 
-if (Qt6_FOUND)
-    target_link_libraries(qgeoview
-                          PRIVATE
-                          Qt6::Core
-                          Qt6::Gui
-                          Qt6::Widgets
-                          Qt6::Network
-                         )
-else()
-    target_link_libraries(qgeoview
-                          PRIVATE
-                          Qt5::Core
-                          Qt5::Gui
-                          Qt5::Widgets
-                          Qt5::Network
-                         )
-endif()
 
+target_link_libraries(qgeoview
+        PRIVATE
+        Qt${QT_VERSION}::Core
+        Qt${QT_VERSION}::Gui
+        Qt${QT_VERSION}::Widgets
+        Qt${QT_VERSION}::Network
+        )
 
 add_library(QGeoView ALIAS qgeoview)
 

--- a/lib/include/QGeoView/QGVWidgetScale.h
+++ b/lib/include/QGeoView/QGVWidgetScale.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "QGVWidget.h"
+#include "utils/DistanceUnits.hpp"
 
 class QGV_LIB_DECL QGVWidgetScale : public QGVWidget
 {
@@ -35,6 +36,9 @@ public:
 
     QString getDistanceLabel(int meters, int accuracy = 0) const;
 
+    void setDistanceUnits(DistanceUnits distanceUnits);
+    void setUseMetersForSmallDistance(bool useMetersForSmallDistance);
+
 private:
     void onCamera(const QGVCameraState& oldState, const QGVCameraState& newState) override;
     void paintEvent(QPaintEvent* event) override;
@@ -44,4 +48,7 @@ private:
     bool mAutoAdjust;
     int mScaleMeters;
     int mScalePixels;
+
+    DistanceUnits mDistanceUnits;
+    bool mUseMetersForSmallDistance;
 };

--- a/lib/include/QGeoView/utils/DistanceUnits.hpp
+++ b/lib/include/QGeoView/utils/DistanceUnits.hpp
@@ -1,0 +1,13 @@
+//
+// Created by Raffaele Montella on 17/01/22.
+//
+
+#ifndef QGEOVIEW_DISTANCEUNITS_HPP
+#define QGEOVIEW_DISTANCEUNITS_HPP
+
+#include "QGeoView/QGVWidget.h"
+
+enum class QGV_LIB_DECL DistanceUnits
+{Kilometers, NauticalMiles, Miles};
+
+#endif // QGEOVIEW_DISTANCEUNITS_HPP

--- a/lib/src/QGVWidgetScale.cpp
+++ b/lib/src/QGVWidgetScale.cpp
@@ -30,6 +30,9 @@ const int minLengthPixel = 130;
 
 QGVWidgetScale::QGVWidgetScale(Qt::Orientation orientation)
 {
+    mDistanceUnits = DistanceUnits::NauticalMiles;
+    mUseMetersForSmallDistance = false;
+
     mAutoAdjust = true;
     mScaleMeters = 0;
     mScalePixels = 0;
@@ -77,11 +80,49 @@ Qt::Orientation QGVWidgetScale::getOrientation() const
 
 QString QGVWidgetScale::getDistanceLabel(int meters, int accuracy) const
 {
-    if (meters > 1000) {
-        return tr("%1 km").arg(QString::number(static_cast<double>(meters) / 1000, 'f', accuracy));
-    } else {
-        return tr("%1 m").arg(QString::number(static_cast<double>(meters), 'f', accuracy));
+    QString result = "";
+    if ( mDistanceUnits == DistanceUnits::Kilometers) {
+        if (mUseMetersForSmallDistance) {
+            if (meters > 1000) {
+                result = tr("%1 km").arg(QString::number(static_cast<double>(meters) / 1000, 'f', accuracy));
+            } else {
+                result = tr("%1 m").arg(QString::number(static_cast<double>(meters), 'f', accuracy));
+            }
+        } else {
+            result = tr("%1 m").arg(QString::number(static_cast<double>(meters), 'f', accuracy));
+        }
+    } else if (mDistanceUnits == DistanceUnits::NauticalMiles) {
+        double nauticalMiles = meters / 1852.0;
+        if (mUseMetersForSmallDistance) {
+            if (nauticalMiles > 1) {
+                result = tr("%1 nm").arg(QString::number(static_cast<double>(nauticalMiles), 'f', accuracy));
+            } else {
+                result = tr("%1 m").arg(QString::number(static_cast<double>(meters), 'f', accuracy));
+            }
+        } else {
+            if (nauticalMiles<1) {
+                accuracy = 2;
+            }
+            result = tr("%1 nm").arg(QString::number(static_cast<double>(nauticalMiles), 'f', accuracy));
+        }
+    } else if (mDistanceUnits == DistanceUnits::Miles) {
+
+        double miles = meters / 1609.0;
+        if (mUseMetersForSmallDistance) {
+            if (miles > 1) {
+                result = tr("%1 mi").arg(QString::number(static_cast<double>(miles), 'f', accuracy));
+            } else {
+                result = tr("%1 m").arg(QString::number(static_cast<double>(meters), 'f', accuracy));
+            }
+        } else {
+            if (miles<1) {
+                accuracy = 2;
+            }
+            result = tr("%1 mi").arg(QString::number(static_cast<double>(miles), 'f', accuracy));
+        }
+
     }
+    return result;
 }
 
 void QGVWidgetScale::onCamera(const QGVCameraState& oldState, const QGVCameraState& newState)
@@ -162,4 +203,12 @@ void QGVWidgetScale::paintEvent(QPaintEvent* /*event*/)
     textRect.moveCenter(paintRect.center());
     painter.setPen(QPen());
     painter.drawText(textRect, Qt::AlignCenter, getDistanceLabel(mScaleMeters));
+}
+void QGVWidgetScale::setDistanceUnits(DistanceUnits distanceUnits)
+{
+    mDistanceUnits = distanceUnits;
+}
+void QGVWidgetScale::setUseMetersForSmallDistance(bool useMetersForSmallDistance)
+{
+    mUseMetersForSmallDistance = useMetersForSmallDistance;
 }

--- a/lib/src/utils/DistanceUnits.cpp
+++ b/lib/src/utils/DistanceUnits.cpp
@@ -1,0 +1,5 @@
+//
+// Created by Raffaele Montella on 17/01/22.
+//
+
+#include "QGeoView/utils/DistanceUnits.hpp"


### PR DESCRIPTION
The Scale widget has been enhanced with three distance units: kilometers, nautical, and miles.
For each distance unit, it is possible to choose if using meters for small distances (less than 1km, less than one nautical mile, less than 1 mile).
The CMakeLists.txt files in the demo and lib have been changed, enabling the developer to choose the QT version manually.

