### PR TITLE
Added BDGEx to the list of background maps.

### DIFF
--- a/demo/samples/background.cpp
+++ b/demo/samples/background.cpp
@@ -22,6 +22,7 @@
 #include <QGeoView/QGVLayerBing.h>
 #include <QGeoView/QGVLayerGoogle.h>
 #include <QGeoView/QGVLayerOSM.h>
+#include <QGeoView/QGVLayerBDGEx.h>
 
 BackgroundDemo::BackgroundDemo(QGVMap* geoMap, QObject* parent)
     : DemoItem(geoMap, SelectorDialog::Single, parent)
@@ -38,7 +39,8 @@ QString BackgroundDemo::comment() const
            "- OpenStreetMaps<br>"
            "- Google Maps<br>"
            "- Bing Maps<br>"
-           "- Custom maps(OSM-like, for e.g MapServer)";
+           "- Custom maps(OSM-like, for e.g MapServer)<br>"
+           "- Banco de Dados Geográfico do Exército";
 }
 
 void BackgroundDemo::onInit()
@@ -62,6 +64,12 @@ void BackgroundDemo::onInit()
         { "BING_HYBRID", new QGVLayerBing(QGV::TilesType::Hybrid) },
         { "BING_SCHEMA", new QGVLayerBing(QGV::TilesType::Schema) },
         { "CUSTOM_OSM", new QGVLayerOSM(customURI) },
+        { "BDGEx CTM25", new QGVLayerBDGEx(QGV::BDGExLayer::ctm25) },
+        { "BDGEx CTM50", new QGVLayerBDGEx(QGV::BDGExLayer::ctm50) },
+        { "BDGEx CTM100", new QGVLayerBDGEx(QGV::BDGExLayer::ctm100) },
+        { "BDGEx CTM250", new QGVLayerBDGEx(QGV::BDGExLayer::ctm250) },
+        { "BDGEx CTM Multi Scale", new QGVLayerBDGEx(QGV::BDGExLayer::ctmmultiescalas) },
+        { "BDGEx CTM Multi Scale Mercator", new QGVLayerBDGEx(QGV::BDGExLayer::ctmmultiescalas_mercator) },
     };
     /*
      * Layers will be owned by map.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(qgeoview SHARED
     include/QGeoView/QGVLayerGoogle.h
     include/QGeoView/QGVLayerBing.h
     include/QGeoView/QGVLayerOSM.h
+	include/QGeoView/QGVLayerBDGEx.h
     include/QGeoView/QGVWidget.h
     include/QGeoView/QGVWidgetCompass.h
     include/QGeoView/QGVWidgetScale.h
@@ -58,6 +59,7 @@ add_library(qgeoview SHARED
     src/QGVLayerGoogle.cpp
     src/QGVLayerBing.cpp
     src/QGVLayerOSM.cpp
+	src/QGVLayerBDGEx.cpp
     src/QGVWidget.cpp
     src/QGVWidgetCompass.cpp
     src/QGVWidgetScale.cpp

--- a/lib/include/QGeoView/QGVGlobal.h
+++ b/lib/include/QGeoView/QGVGlobal.h
@@ -46,6 +46,16 @@ enum class TilesType
     Hybrid,
 };
 
+enum BDGExLayer
+{
+    ctm25,
+    ctm50,
+    ctm100,
+    ctm250,
+    ctmmultiescalas,
+    ctmmultiescalas_mercator
+};
+
 enum class MapState
 {
     Idle,

--- a/lib/include/QGeoView/QGVLayerBDGEx.h
+++ b/lib/include/QGeoView/QGVLayerBDGEx.h
@@ -1,0 +1,41 @@
+/***************************************************************************
+ * QGeoView is a Qt / C ++ widget for visualizing geographic data.
+ * Copyright (C) 2018-2022 Andrey Yaroshenko.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, see https://www.gnu.org/licenses.
+ ****************************************************************************/
+
+#pragma once
+
+#include "QGVLayerTilesOnline.h"
+
+class QGV_LIB_DECL QGVLayerBDGEx : public QGVLayerTilesOnline
+{
+    Q_OBJECT
+
+public:
+    explicit QGVLayerBDGEx(int serverNumber = 4);
+    explicit QGVLayerBDGEx(const QString& url);
+
+    void setUrl(const QString& url);
+    QString getUrl() const;
+
+private:
+    int minZoomlevel() const override;
+    int maxZoomlevel() const override;
+    QString tilePosToUrl(const QGV::GeoTilePos& tilePos) const override;
+
+private:
+    QString mUrl;
+};

--- a/lib/lib.pri
+++ b/lib/lib.pri
@@ -13,6 +13,7 @@ SOURCES += \
     $$PWD/src/QGVLayerBing.cpp \
     $$PWD/src/QGVLayerGoogle.cpp \
     $$PWD/src/QGVLayerOSM.cpp \
+	$$PWD/src/QGVLayerBDGEx.cpp \
     $$PWD/src/QGVLayerTiles.cpp \
     $$PWD/src/QGVLayerTilesOnline.cpp \
     $$PWD/src/QGVMap.cpp \
@@ -38,6 +39,7 @@ HEADERS += \
     $$PWD/include/QGeoView/QGVLayerBing.h \
     $$PWD/include/QGeoView/QGVLayerGoogle.h \
     $$PWD/include/QGeoView/QGVLayerOSM.h \
+	$$PWD/include/QGeoView/QGVLayerBDGEx.h \
     $$PWD/include/QGeoView/QGVLayerTiles.h \
     $$PWD/include/QGeoView/QGVLayerTilesOnline.h \
     $$PWD/include/QGeoView/QGVMap.h \

--- a/lib/src/QGVLayerBDGEx.cpp
+++ b/lib/src/QGVLayerBDGEx.cpp
@@ -1,0 +1,93 @@
+/***************************************************************************
+ * QGeoView is a Qt / C ++ widget for visualizing geographic data.
+ * Copyright (C) 2018-2022 Andrey Yaroshenko.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, see https://www.gnu.org/licenses.
+ ****************************************************************************/
+
+#include "QGVLayerBDGEx.h"
+
+#include <QtMath>
+
+namespace {
+// clang-format off
+const QStringList URLTemplates = {
+    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctm25&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRigth,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
+    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctm50&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRigth,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
+    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctm100&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRigth,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
+    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctm250&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRigth,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
+    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctm250&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRigth,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
+    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctmmultiescalas&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRigth,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
+    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctmmultiescalas_mercator&srs=EPSG%3A3857&bbox=lonLeft,latBottom,lonRigth,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng"
+};
+// clang-format on
+}
+
+QGVLayerBDGEx::QGVLayerBDGEx(int serverNumber)
+    : mUrl(URLTemplates.value(serverNumber))
+{
+    setName("Banco de Dados Geográfico do Exército");
+    setDescription("Copyrights: \"Termo de Uso do BDGEx\"");
+}
+
+QGVLayerBDGEx::QGVLayerBDGEx(const QString& url)
+    : mUrl(url)
+{
+    setName("Padrão");
+    setDescription("Carta Topográfica Matricial");
+}
+
+void QGVLayerBDGEx::setUrl(const QString& url)
+{
+    mUrl = url;
+}
+
+QString QGVLayerBDGEx::getUrl() const
+{
+    return mUrl;
+}
+
+int QGVLayerBDGEx::minZoomlevel() const
+{
+    return 0;
+}
+
+int QGVLayerBDGEx::maxZoomlevel() const
+{
+    return 20;
+}
+
+QString QGVLayerBDGEx::tilePosToUrl(const QGV::GeoTilePos& tilePos) const
+{
+    QString url = mUrl;
+    //    url.replace("${z}", QString::number(tilePos.zoom()));
+    //    url.replace("${x}", QString::number(tilePos.pos().x()));
+    //    url.replace("${y}", QString::number(tilePos.pos().y()));
+    QGV::GeoRect rect = tilePos.toGeoRect();
+    url.replace("lonLeft", QString::number(rect.lonLeft(),'f',6));
+    url.replace("latBottom", QString::number(rect.latBottom(),'f',6));
+    url.replace("lonRigth", QString::number(rect.lonRigth(),'f',6));
+    url.replace("latTop", QString::number(rect.latTop(),'f',6));
+    double m_width = rect.lonRigth() - rect.lonLeft();
+    double m_height = rect.latTop() - rect.latBottom();
+    double ratio = m_width/m_height;
+    int width_pixels = 900;
+    int height_pixels = (int)((double)width_pixels / ratio);
+    url.replace("WIDTH", QString::number(width_pixels));
+    url.replace("HEIGHT", QString::number(height_pixels));
+    //qDebug() << rect.lonLeft() << rect.latBottom() << rect.lonRigth() << rect.latTop() << width_pixels << height_pixels;
+    //qDebug() << bdgexURL;
+    return url;
+    return url;
+}

--- a/lib/src/QGVLayerTilesOnline.cpp
+++ b/lib/src/QGVLayerTilesOnline.cpp
@@ -41,6 +41,9 @@ void QGVLayerTilesOnline::request(const QGV::GeoTilePos& tilePos)
 {
     const QUrl url(tilePosToUrl(tilePos));
     QNetworkRequest request(url);
+    QSslConfiguration conf = request.sslConfiguration();
+    conf.setPeerVerifyMode(QSslSocket::VerifyNone);
+    request.setSslConfiguration(conf);
     request.setRawHeader("User-Agent",
                          "Mozilla/5.0 (Windows; U; MSIE "
                          "6.0; Windows NT 5.1; SV1; .NET "


### PR DESCRIPTION
BDGEx (Banco de Dados Geográficos do Exército, which stands for Army Geographic Database) is the Brazilian Army official source of maps. The maps are requested via HTTP request to the official WMS server [http://bdgex.eb.mil.br/mapcache](http://bdgex.eb.mil.br/mapcache). Issue [#32.](https://github.com/AmonRaNet/QGeoView/issues/32)