### PR TITLE
Various fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(QGeoView LANGUAGES C CXX)
 

--- a/lib/include/QGeoView/QGVGlobal.h
+++ b/lib/include/QGeoView/QGVGlobal.h
@@ -121,6 +121,9 @@ public:
     static QString lonToString(double lon, const QString& format = "[+-]d");
     static QString latToString(double lat, const QString& format = "[+-]d");
 
+    bool operator==(const GeoPos& rhs);
+    bool operator!=(const GeoPos& rhs);
+
 private:
     bool mEmpty;
     double mLat;
@@ -141,13 +144,16 @@ public:
     GeoPos bottomLeft() const;
     GeoPos bottomRight() const;
     double lonLeft() const;
-    double lonRigth() const;
+    double lonRight() const;
     double latBottom() const;
     double latTop() const;
 
     bool contains(GeoPos const& pos) const;
     bool contains(GeoRect const& rect) const;
     bool intersects(GeoRect const& rect) const;
+
+    bool operator==(const GeoRect& rhs);
+    bool operator!=(const GeoRect& rhs);
 
 private:
     GeoPos mTopLeft;

--- a/lib/src/QGVGlobal.cpp
+++ b/lib/src/QGVGlobal.cpp
@@ -156,6 +156,16 @@ QString GeoPos::latToString(double lat, const QString& format)
     return result;
 }
 
+bool GeoPos::operator==(const GeoPos& rhs)
+{
+    return (mEmpty && rhs.mEmpty) || (mLat == rhs.mLat && mLon == rhs.mLon);
+}
+
+bool GeoPos::operator!=(const GeoPos& rhs)
+{
+    return !(*this == rhs);
+}
+
 GeoRect::GeoRect()
 {
 }
@@ -202,7 +212,7 @@ double GeoRect::lonLeft() const
     return mTopLeft.longitude();
 }
 
-double GeoRect::lonRigth() const
+double GeoRect::lonRight() const
 {
     return mBottomRight.longitude();
 }
@@ -219,13 +229,13 @@ double GeoRect::latTop() const
 
 bool GeoRect::contains(GeoPos const& pos) const
 {
-    return (lonLeft() <= pos.longitude() && pos.longitude() < lonRigth() && latBottom() < pos.latitude() &&
+    return (lonLeft() <= pos.longitude() && pos.longitude() < lonRight() && latBottom() < pos.latitude() &&
             pos.latitude() <= latTop());
 }
 
 bool GeoRect::contains(GeoRect const& rect) const
 {
-    return (lonLeft() <= rect.lonLeft() && rect.lonRigth() <= lonRigth() && latBottom() <= rect.latBottom() &&
+    return (lonLeft() <= rect.lonLeft() && rect.lonRight() <= lonRight() && latBottom() <= rect.latBottom() &&
             rect.latTop() <= latTop());
 }
 
@@ -234,6 +244,16 @@ bool GeoRect::intersects(const GeoRect& rect) const
     return contains(rect.topLeft()) || contains(rect.topRight()) || contains(rect.bottomLeft()) ||
            contains(rect.bottomRight()) || rect.contains(topLeft()) || rect.contains(topRight()) ||
            rect.contains(bottomLeft()) || rect.contains(bottomRight());
+}
+
+bool GeoRect::operator==(const GeoRect& rhs)
+{
+    return mTopLeft == rhs.mTopLeft && mBottomRight == rhs.mBottomRight;
+}
+
+bool GeoRect::operator!=(const GeoRect& rhs)
+{
+    return !(*this == rhs);
 }
 
 GeoTilePos::GeoTilePos()

--- a/lib/src/QGVLayerBDGEx.cpp
+++ b/lib/src/QGVLayerBDGEx.cpp
@@ -23,13 +23,13 @@
 namespace {
 // clang-format off
 const QStringList URLTemplates = {
-    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctm25&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRigth,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
-    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctm50&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRigth,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
-    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctm100&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRigth,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
-    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctm250&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRigth,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
-    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctm250&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRigth,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
-    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctmmultiescalas&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRigth,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
-    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctmmultiescalas_mercator&srs=EPSG%3A3857&bbox=lonLeft,latBottom,lonRigth,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng"
+    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctm25&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRight,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
+    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctm50&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRight,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
+    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctm100&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRight,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
+    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctm250&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRight,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
+    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctm250&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRight,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
+    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctmmultiescalas&srs=EPSG%3A4326&bbox=lonLeft,latBottom,lonRight,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng",
+    "http://bdgex.eb.mil.br/mapcache?request=GetMap&service=WMS&version=1.1.1&layers=ctmmultiescalas_mercator&srs=EPSG%3A3857&bbox=lonLeft,latBottom,lonRight,latTop&width=WIDTH&height=HEIGHT&format=image%2Fpng"
 };
 // clang-format on
 }
@@ -74,9 +74,9 @@ QString QGVLayerBDGEx::tilePosToUrl(const QGV::GeoTilePos& tilePos) const
     QGV::GeoRect rect = tilePos.toGeoRect();
     url.replace("lonLeft", QString::number(rect.lonLeft(), 'f', 6));
     url.replace("latBottom", QString::number(rect.latBottom(), 'f', 6));
-    url.replace("lonRigth", QString::number(rect.lonRigth(), 'f', 6));
+    url.replace("lonRight", QString::number(rect.lonRight(), 'f', 6));
     url.replace("latTop", QString::number(rect.latTop(), 'f', 6));
-    double m_width = rect.lonRigth() - rect.lonLeft();
+    double m_width = rect.lonRight() - rect.lonLeft();
     double m_height = rect.latTop() - rect.latBottom();
     double ratio = m_width / m_height;
     int width_pixels = 900;

--- a/samples/fun/mainwindow.cpp
+++ b/samples/fun/mainwindow.cpp
@@ -101,7 +101,7 @@ QPixmap MainWindow::createQGVImage() const
 QGVLayer* MainWindow::createQGVLayer() const
 {
     const auto target = targetQGVArea();
-    const auto sizeLon = target.lonLeft() - target.lonRigth();
+    const auto sizeLon = target.lonLeft() - target.lonRight();
     const auto sizeLat = target.latTop() - target.latBottom();
 
     /*

--- a/samples/shared/helpers.cpp
+++ b/samples/shared/helpers.cpp
@@ -51,7 +51,7 @@ QGV::GeoRect Helpers::randRect(QGVMap* geoMap, const QGV::GeoRect& targetArea)
 QGV::GeoPos Helpers::randPos(const QGV::GeoRect& targetArea)
 {
     const double latRange = targetArea.latTop() - targetArea.latBottom();
-    const double lonRange = targetArea.lonRigth() - targetArea.lonLeft();
+    const double lonRange = targetArea.lonRight() - targetArea.lonLeft();
     static const int range = 1000;
 
     return { targetArea.latBottom() + latRange * (randomInt(0, range)) / range,


### PR DESCRIPTION
CMake 4 and newer can no longer process scripts with a minimum requirement of less than CMake 3.5.

A spelling mistake has crept in with ‘right’.