### PR TITLE
Fix leaving residuals when dragging the map rapidly

### DIFF
--- a/samples/moving-objects/mainwindow.cpp
+++ b/samples/moving-objects/mainwindow.cpp
@@ -33,6 +33,10 @@ MainWindow::MainWindow()
     mMap = new QGVMap(this);
     setCentralWidget(mMap);
 
+    // fix leaving residuals when dragging the map rapidly
+    mMap->geoView()->setViewportUpdateMode(QGraphicsView::ViewportUpdateMode::FullViewportUpdate);
+    mMap->geoView()->setCacheMode(QGraphicsView::CacheModeFlag::CacheBackground);
+
     Helpers::setupCachedNetworkAccessManager(this);
 
     // Background layer


### PR DESCRIPTION
This fixes leaving residuals when dragging the map rapidly.

<img width="1901" height="1015" alt="moving_objects" src="https://github.com/user-attachments/assets/cd7015f3-4a6a-478d-8c27-b8fe98cc15f8" />
